### PR TITLE
Add gutter icon for the And keyword and proper test path entry to all…

### DIFF
--- a/src/test/kotlin/io/kotest/plugin/intellij/intentions/ShouldThrowIntentionTest.kt
+++ b/src/test/kotlin/io/kotest/plugin/intellij/intentions/ShouldThrowIntentionTest.kt
@@ -61,9 +61,17 @@ class BehaviorSpecExample : BehaviorSpec() {
           }
         }
       }
+      and("an and") {
+        `when`("a when") {
+          then("a test") {
+            //test here
+          }
+        }
+      }
     }
   }
-}"""
+}
+"""
   }
 
   fun testIntentionForFullLine() {
@@ -114,8 +122,16 @@ class BehaviorSpecExample : BehaviorSpec() {
           }
         }
       }
+      and("an and") {
+        `when`("a when") {
+          then("a test") {
+            //test here
+          }
+        }
+      }
     }
   }
-}"""
+}
+"""
   }
 }

--- a/src/test/kotlin/io/kotest/plugin/intellij/styles/BehaviorSpecRunMarkerTest.kt
+++ b/src/test/kotlin/io/kotest/plugin/intellij/styles/BehaviorSpecRunMarkerTest.kt
@@ -22,7 +22,7 @@ class BehaviorSpecRunMarkerTest : LightJavaCodeInsightFixtureTestCase() {
 
       val gutters = myFixture.findAllGutters()
       println(gutters.map { it.tooltipText }.joinToString("\n"))
-      gutters.size shouldBe 8
+      gutters.size shouldBe 11
 
       gutters[0].icon shouldBe AllIcons.RunConfigurations.TestState.Run
       gutters[0].tooltipText shouldBe "Run BehaviorSpecExample"
@@ -55,6 +55,18 @@ class BehaviorSpecRunMarkerTest : LightJavaCodeInsightFixtureTestCase() {
       gutters[7].icon shouldBe AllIcons.RunConfigurations.TestState.Run
       gutters[7].tooltipText shouldBe "Run a given another when a test with config"
       (gutters[7] as LineMarkerInfo.LineMarkerGutterIconRenderer<*>).lineMarkerInfo.startOffset shouldBe 545
+
+      gutters[8].icon shouldBe AllIcons.RunConfigurations.TestState.Run
+      gutters[8].tooltipText shouldBe "Run a given an and"
+      (gutters[8] as LineMarkerInfo.LineMarkerGutterIconRenderer<*>).lineMarkerInfo.startOffset shouldBe 637
+
+      gutters[9].icon shouldBe AllIcons.RunConfigurations.TestState.Run
+      gutters[9].tooltipText shouldBe "Run a given an and a when"
+      (gutters[9] as LineMarkerInfo.LineMarkerGutterIconRenderer<*>).lineMarkerInfo.startOffset shouldBe 664
+
+      gutters[10].icon shouldBe AllIcons.RunConfigurations.TestState.Run
+      gutters[10].tooltipText shouldBe "Run a given an and a when a test"
+      (gutters[10] as LineMarkerInfo.LineMarkerGutterIconRenderer<*>).lineMarkerInfo.startOffset shouldBe 691
    }
 
    fun testMethodGeneration() {

--- a/src/test/resources/behaviorspec.kt
+++ b/src/test/resources/behaviorspec.kt
@@ -24,6 +24,13 @@ class BehaviorSpecExample : BehaviorSpec() {
           1 + 1 shouldBe 2
         }
       }
+      and("an and") {
+        `when`("a when") {
+          then("a test") {
+            //test here
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
… test nested in And

Greetings.

First of all thank you for the great testing framework. And I hope you will find my first commit useful.

I've noticed that for `and` keyword gutter icons are not generated. And even more, on clicking on gutter icon for any test nested in `and` test path misses and-part which leads to malformed test path and effectively to fail to run the test.

After some time I've managed to build plugin from sources and come up with the following solution.

I've tested it on my local IDEA 2020.3.2 installation, and it does work.

Alas, I couldn't test it on fresh master branch as it's broken at the moment. So I took latest stable revision (ae8e77ea49367f00845ed1c56d63aaa71e354fc1 Fixed is spec from 22/12/2020). But I hope that pretty trivial code would work on fresh master and IDEAs as well.

Please review my solution. )

P.S. I've seen similar issues on `context` keyword and believe it could be fixed pretty much the same way. But first I want to check if my approach meets contribution guidelines if any.