### PR TITLE
Fix build for 2022.1 EAP

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,11 @@
 import de.fayard.refreshVersions.core.StabilityLevel
 
 plugins {
+   // refreshVersions uses Kotlin 1.4.20 but Intellij 2022.1 requires Kotlin 1.6.0.
+   // In order to fix the Kotlin version to 1.6.0, we need to set the Kotlin plugin
+   // here already, because otherwise the Kotlin version from refreshVersions will
+   // be used everywhere, leading to compiler errors.
+   kotlin("jvm").version("1.6.0").apply(false)
    id("de.fayard.refreshVersions") version "0.21.0"
 }
 


### PR DESCRIPTION
The refreshVersions plugin uses the Kotlin Gradle plugin. The problem here is that the first time a Gradle plugin is activated determines the used version, which for the Kotlin plugin also automatically determines the Kotlin language version. refreshVersions uses 1.4.20, which is incompatible with the Intellij 2022.1 sources, which were compiled using Kotlin 1.6.0. Adding the Kotlin plugin in the correct version in settings.gradle.kts before refreshVersions without applying it fixes its version to 1.6.0 for the whole project and makes everything compile as it should.

This is related to #162 