### PR TITLE
Replace escaped quotes with quotes when interpreting test names

### DIFF
--- a/src/main/kotlin/io/kotest/plugin/intellij/psi/strings.kt
+++ b/src/main/kotlin/io/kotest/plugin/intellij/psi/strings.kt
@@ -3,5 +3,5 @@ package io.kotest.plugin.intellij.psi
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 
 fun KtStringTemplateExpression.asString(): StringArg {
-   return StringArg(entries.joinToString("") { it.text }, hasInterpolation())
+   return StringArg(entries.joinToString("") { it.text.replace("\\\"", "\"") }, hasInterpolation())
 }

--- a/src/test/kotlin/io/kotest/plugin/intellij/styles/FunSpecRunMarkerTest.kt
+++ b/src/test/kotlin/io/kotest/plugin/intellij/styles/FunSpecRunMarkerTest.kt
@@ -73,6 +73,10 @@ class FunSpecRunMarkerTest : LightJavaCodeInsightFixtureTestCase() {
          Gutter("Run context with config a test inside a context with config", 1314),
          Gutter("Disabled - xcontext with config", 1365, AllIcons.RunConfigurations.TestIgnored),
          Gutter("Disabled - xcontext with config a test inside an xcontext with config", 1443, AllIcons.RunConfigurations.TestIgnored),
+
+         // Previously the PSI text was fetched which contains the raw text entered, not parsed string, which means it would include the backslashes as well.
+         // See https://github.com/kotest/kotest/issues/3078
+         Gutter("""Run name containing "escaped quotes"""", 1505),
       )
 
       gutters.size shouldBe expected.size

--- a/src/test/resources/funspec.kt
+++ b/src/test/resources/funspec.kt
@@ -76,4 +76,7 @@ class FunSpecExampleTest : FunSpec({
       test("a test inside an xcontext with config") {
       }
    }
+
+   test("name containing \"escaped quotes\"") {
+   }
 })


### PR DESCRIPTION
Fixes https://github.com/kotest/kotest/issues/3078