### PR TITLE
Added tags display to kotest tool window

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
          matrix:
             product: [ "IC-211", "IC-212", "IC-213", "IC-221", "IC-222" ]
          max-parallel: 6
+         fail-fast: false
 
       steps:
          -  uses: actions/checkout@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,6 +14,7 @@ jobs:
          matrix:
             product: [  "IC-211", "IC-212", "IC-213", "IC-221", "IC-222" ]
          max-parallel: 10
+         fail-fast: false
 
       steps:
          -  uses: actions/checkout@v3

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,7 +84,7 @@ val plugins = listOf(
    )
 )
 
-val productName = System.getenv("PRODUCT_NAME") ?: "IC-213"
+val productName = System.getenv("PRODUCT_NAME") ?: "IC-222"
 val descriptor = plugins.first { it.sourceFolder == productName }
 
 val jetbrainsToken: String by project

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,7 +84,7 @@ val plugins = listOf(
    )
 )
 
-val productName = System.getenv("PRODUCT_NAME") ?: "IC-221"
+val productName = System.getenv("PRODUCT_NAME") ?: "IC-212"
 val descriptor = plugins.first { it.sourceFolder == productName }
 
 val jetbrainsToken: String by project

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,7 +84,7 @@ val plugins = listOf(
    )
 )
 
-val productName = System.getenv("PRODUCT_NAME") ?: "IC-212"
+val productName = System.getenv("PRODUCT_NAME") ?: "IC-213"
 val descriptor = plugins.first { it.sourceFolder == productName }
 
 val jetbrainsToken: String by project

--- a/src/IC-211/kotlin/io/kotest/plugin/intellij/files.kt
+++ b/src/IC-211/kotlin/io/kotest/plugin/intellij/files.kt
@@ -1,0 +1,13 @@
+package io.kotest.plugin.intellij
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.psi.search.GlobalSearchScope
+import io.kotest.plugin.intellij.toolwindow.TagsFilename
+
+fun findFiles(project: Project): List<VirtualFile> {
+   return FilenameIndex
+      .getVirtualFilesByName(project, TagsFilename, false, GlobalSearchScope.allScope(project))
+      .toList()
+}

--- a/src/IC-212/kotlin/io/kotest/plugin/intellij/files.kt
+++ b/src/IC-212/kotlin/io/kotest/plugin/intellij/files.kt
@@ -1,0 +1,13 @@
+package io.kotest.plugin.intellij
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.psi.search.GlobalSearchScope
+import io.kotest.plugin.intellij.toolwindow.TagsFilename
+
+fun findFiles(project: Project): List<VirtualFile> {
+   return FilenameIndex
+      .getVirtualFilesByName(project, TagsFilename, false, GlobalSearchScope.allScope(project))
+      .toList()
+}

--- a/src/IC-213/kotlin/io/kotest/plugin/intellij/files.kt
+++ b/src/IC-213/kotlin/io/kotest/plugin/intellij/files.kt
@@ -1,0 +1,13 @@
+package io.kotest.plugin.intellij
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.psi.search.GlobalSearchScope
+import io.kotest.plugin.intellij.toolwindow.TagsFilename
+
+fun findFiles(project: Project): List<VirtualFile> {
+   return FilenameIndex
+      .getVirtualFilesByName(project, TagsFilename, false, GlobalSearchScope.allScope(project))
+      .toList()
+}

--- a/src/IC-221/kotlin/io/kotest/plugin/intellij/files.kt
+++ b/src/IC-221/kotlin/io/kotest/plugin/intellij/files.kt
@@ -1,0 +1,13 @@
+package io.kotest.plugin.intellij
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.psi.search.GlobalSearchScope
+import io.kotest.plugin.intellij.toolwindow.TagsFilename
+
+fun findFiles(project: Project): List<VirtualFile> {
+   return FilenameIndex
+      .getVirtualFilesByName(project, TagsFilename, false, GlobalSearchScope.allScope(project))
+      .toList()
+}

--- a/src/IC-222/kotlin/io/kotest/plugin/intellij/files.kt
+++ b/src/IC-222/kotlin/io/kotest/plugin/intellij/files.kt
@@ -1,0 +1,13 @@
+package io.kotest.plugin.intellij
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.psi.search.GlobalSearchScope
+import io.kotest.plugin.intellij.toolwindow.TagsFilename
+
+fun findFiles(project: Project): List<VirtualFile> {
+   return FilenameIndex
+      .getVirtualFilesByName(project, TagsFilename, false, GlobalSearchScope.allScope(project))
+      .toList()
+}

--- a/src/main/kotlin/io/kotest/plugin/intellij/psi/classes.kt
+++ b/src/main/kotlin/io/kotest/plugin/intellij/psi/classes.kt
@@ -35,10 +35,6 @@ fun PsiFile.classes(): List<KtClass> {
    return this.getChildrenOfType<KtClass>().asList()
 }
 
-fun PsiFile.classesOrObjects(): List<KtClassOrObject> {
-   return this.getChildrenOfType<KtClassOrObject>().asList()
-}
-
 /**
  * Returns the first [KtClass] parent of this element.
  */

--- a/src/main/kotlin/io/kotest/plugin/intellij/psi/classes.kt
+++ b/src/main/kotlin/io/kotest/plugin/intellij/psi/classes.kt
@@ -2,7 +2,6 @@ package io.kotest.plugin.intellij.psi
 
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
-import com.intellij.psi.util.childrenOfType
 import org.jetbrains.kotlin.asJava.classes.KtLightClass
 import org.jetbrains.kotlin.idea.caches.resolve.analyze
 import org.jetbrains.kotlin.name.FqName
@@ -36,7 +35,7 @@ fun PsiFile.classes(): List<KtClass> {
    return this.getChildrenOfType<KtClass>().asList()
 }
 
-fun PsiFile.classesOrObjects(): List<> {
+fun PsiFile.classesOrObjects(): List<KtClassOrObject> {
    return this.getChildrenOfType<KtClassOrObject>().asList()
 }
 

--- a/src/main/kotlin/io/kotest/plugin/intellij/psi/classes.kt
+++ b/src/main/kotlin/io/kotest/plugin/intellij/psi/classes.kt
@@ -2,6 +2,7 @@ package io.kotest.plugin.intellij.psi
 
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.util.childrenOfType
 import org.jetbrains.kotlin.asJava.classes.KtLightClass
 import org.jetbrains.kotlin.idea.caches.resolve.analyze
 import org.jetbrains.kotlin.name.FqName
@@ -33,6 +34,10 @@ fun KtClassOrObject.toKtClass(): KtClass? = if (this is KtClass) this else null
  */
 fun PsiFile.classes(): List<KtClass> {
    return this.getChildrenOfType<KtClass>().asList()
+}
+
+fun PsiFile.classesOrObjects(): List<KtClassOrObject> {
+   return this.childrenOfType()
 }
 
 /**

--- a/src/main/kotlin/io/kotest/plugin/intellij/psi/classes.kt
+++ b/src/main/kotlin/io/kotest/plugin/intellij/psi/classes.kt
@@ -36,8 +36,8 @@ fun PsiFile.classes(): List<KtClass> {
    return this.getChildrenOfType<KtClass>().asList()
 }
 
-fun PsiFile.classesOrObjects(): List<KtClassOrObject> {
-   return this.childrenOfType()
+fun PsiFile.classesOrObjects(): List<> {
+   return this.getChildrenOfType<KtClassOrObject>().asList()
 }
 
 /**

--- a/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/TestExplorerState.kt
+++ b/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/TestExplorerState.kt
@@ -1,8 +1,12 @@
 package io.kotest.plugin.intellij.toolwindow
 
 object TestExplorerState {
+
    var showCallbacks = true
+   var showTags = true
    var showModules = true
    var showIncludes = true
    var autoscrollToSource = true
+
+   var tags: List<String> = emptyList()
 }

--- a/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/TestExplorerWindow.kt
+++ b/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/TestExplorerWindow.kt
@@ -95,9 +95,13 @@ class TestExplorerWindow(private val project: Project) : SimpleToolWindowPanel(t
       }
       val manager = PsiManager.getInstance(project)
       manager.addPsiTreeChangeListener(listener) { manager.removePsiTreeChangeListener(listener) }
+
+      val tagsListener = KotestTagFileListener(tree, project)
+      manager.addPsiTreeChangeListener(tagsListener) { manager.removePsiTreeChangeListener(tagsListener) }
    }
 
    private fun refreshContent() {
+      scanTags(project)
       val file = fileEditorManager.selectedEditor?.file
       tree.setVirtualFile(file)
    }

--- a/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/descriptors.kt
+++ b/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/descriptors.kt
@@ -43,9 +43,24 @@ class ModulesNodeDescriptor(project: Project) : PresentableNodeDescriptor<Any>(p
    override fun getElement(): Any = this
 }
 
-class TestFileNodeDescriptor(file: VirtualFile,
-                             project: Project,
-                             parent: NodeDescriptor<Any>) : PresentableNodeDescriptor<Any>(project, parent) {
+class TagsNodeDescriptor(project: Project) : PresentableNodeDescriptor<Any>(project, null) {
+   init {
+      templatePresentation.presentableText = "Tags"
+      templatePresentation.setIcon(AllIcons.Nodes.Tag)
+   }
+
+   override fun update(presentation: PresentationData) {
+      presentation.isChanged = false
+   }
+
+   override fun getElement(): Any = this
+}
+
+class TestFileNodeDescriptor(
+   file: VirtualFile,
+   project: Project,
+   parent: NodeDescriptor<Any>
+) : PresentableNodeDescriptor<Any>(project, parent) {
 
    init {
       templatePresentation.presentableText = file.name
@@ -59,12 +74,14 @@ class TestFileNodeDescriptor(file: VirtualFile,
    override fun getElement(): Any = this
 }
 
-class SpecNodeDescriptor(project: Project,
-                         val parent: NodeDescriptor<Any>,
-                         val psi: KtClassOrObject,
-                         val fqn: FqName,
-                         val style: SpecStyle,
-                         val module: Module) : PresentableNodeDescriptor<Any>(project, parent) {
+class SpecNodeDescriptor(
+   project: Project,
+   val parent: NodeDescriptor<Any>,
+   val psi: KtClassOrObject,
+   val fqn: FqName,
+   val style: SpecStyle,
+   val module: Module
+) : PresentableNodeDescriptor<Any>(project, parent) {
 
    init {
       templatePresentation.presentableText = fqn.asString()
@@ -79,13 +96,15 @@ class SpecNodeDescriptor(project: Project,
    override fun getElement(): Any = this
 }
 
-class TestNodeDescriptor(project: Project,
-                         val parent: NodeDescriptor<Any>,
-                         val psi: PsiElement,
-                         val test: TestElement,
-                         val spec: SpecNodeDescriptor,
-                         isUnique: Boolean, // if false then this test name is a duplicate
-                         val module: Module) : PresentableNodeDescriptor<Any>(project, parent) {
+class TestNodeDescriptor(
+   project: Project,
+   val parent: NodeDescriptor<Any>,
+   val psi: PsiElement,
+   val test: TestElement,
+   val spec: SpecNodeDescriptor,
+   isUnique: Boolean, // if false then this test name is a duplicate
+   val module: Module
+) : PresentableNodeDescriptor<Any>(project, parent) {
 
    init {
       templatePresentation.locationString = null
@@ -109,10 +128,12 @@ class TestNodeDescriptor(project: Project,
    override fun getElement(): Any = this
 }
 
-class CallbackNodeDescriptor(project: Project,
-                             parent: SpecNodeDescriptor,
-                             val psi: PsiElement,
-                             callback: Callback) : PresentableNodeDescriptor<Any>(project, parent) {
+class CallbackNodeDescriptor(
+   project: Project,
+   parent: SpecNodeDescriptor,
+   val psi: PsiElement,
+   callback: Callback
+) : PresentableNodeDescriptor<Any>(project, parent) {
 
    init {
       templatePresentation.presentableText = callback.type.text
@@ -137,9 +158,14 @@ class CallbackNodeDescriptor(project: Project,
    override fun getElement(): Any = this
 }
 
-class ModuleNodeDescriptor(val module: Module,
-                           project: Project,
-                           parent: NodeDescriptor<Any>) : PresentableNodeDescriptor<Any>(project, parent) {
+/**
+ * [NodeDescriptor] for an individual module in the project.
+ */
+class ModuleNodeDescriptor(
+   val module: Module,
+   project: Project,
+   parent: NodeDescriptor<Any>
+) : PresentableNodeDescriptor<Any>(project, parent) {
 
    init {
       templatePresentation.presentableText = module.name
@@ -153,10 +179,33 @@ class ModuleNodeDescriptor(val module: Module,
    override fun getElement(): Any = this
 }
 
-class IncludeNodeDescriptor(project: Project,
-                            parent: SpecNodeDescriptor,
-                            val psi: PsiElement,
-                            val include: Include) : PresentableNodeDescriptor<Any>(project, parent) {
+/**
+ * [NodeDescriptor] for a detected kotest tag.
+ */
+class TagNodeDescriptor(
+   private val tag: String,
+   project: Project,
+   parent: NodeDescriptor<Any>
+) : PresentableNodeDescriptor<Any>(project, parent) {
+
+   init {
+      templatePresentation.presentableText = tag
+      templatePresentation.setIcon(AllIcons.Nodes.Tag)
+   }
+
+   override fun update(presentation: PresentationData) {
+      presentation.isChanged = false
+   }
+
+   override fun getElement(): Any = this
+}
+
+class IncludeNodeDescriptor(
+   project: Project,
+   parent: SpecNodeDescriptor,
+   val psi: PsiElement,
+   val include: Include
+) : PresentableNodeDescriptor<Any>(project, parent) {
 
    init {
       templatePresentation.presentableText = "Include: ${include.name}"

--- a/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/tags.kt
+++ b/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/tags.kt
@@ -4,8 +4,7 @@ import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiTreeAnyChangeAbstractAdapter
-import com.intellij.psi.search.FilenameIndex
-import com.intellij.psi.search.GlobalSearchScope
+import io.kotest.plugin.intellij.findFiles
 import io.kotest.plugin.intellij.psi.getAllSuperClasses
 import org.jetbrains.kotlin.idea.core.util.toPsiFile
 import org.jetbrains.kotlin.name.FqName
@@ -48,8 +47,7 @@ fun PsiFile.detectKotestTags(): List<String> {
 
 fun scanTags(project: Project) {
    DumbService.getInstance(project).runWhenSmart {
-      TestExplorerState.tags = FilenameIndex
-         .getVirtualFilesByName(TagsFilename, false, GlobalSearchScope.allScope(project))
+      TestExplorerState.tags = findFiles(project)
          .mapNotNull { it.toPsiFile(project) }
          .flatMap { it.detectKotestTags() }
          .distinct()

--- a/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/tags.kt
+++ b/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/tags.kt
@@ -1,0 +1,58 @@
+package io.kotest.plugin.intellij.toolwindow
+
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiTreeAnyChangeAbstractAdapter
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.psi.search.GlobalSearchScope
+import io.kotest.plugin.intellij.psi.getAllSuperClasses
+import org.jetbrains.kotlin.idea.core.util.toPsiFile
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtProperty
+
+const val TagsFilename = "KotestTags.kt"
+val TagSuperClass = FqName("io.kotest.core.Tag")
+
+/**
+ * Whenever the special KotestTags file changes,
+ * we look for tags in it and update the state. Then we
+ * cause the tree model to refresh
+ */
+class KotestTagFileListener(
+   private val tree: TestFileTree,
+   private val project: Project,
+) : PsiTreeAnyChangeAbstractAdapter() {
+   override fun onChange(file: PsiFile?) {
+      if (file == null) return
+      if (file.name == TagsFilename) {
+         scanTags(project)
+         tree.reloadModel()
+      }
+   }
+}
+
+/**
+ * Looks for Kotest tags in this file, defined at the top level as either vals or anon objects.
+ */
+fun PsiFile.detectKotestTags(): List<String> {
+   return children.mapNotNull {
+      when (it) {
+         is KtClassOrObject -> if (it.getAllSuperClasses().contains(TagSuperClass)) it.name else null
+         is KtProperty -> it.name
+         else -> null
+      }
+   }
+}
+
+fun scanTags(project: Project) {
+   DumbService.getInstance(project).runWhenSmart {
+      TestExplorerState.tags = FilenameIndex
+         .getVirtualFilesByName(TagsFilename, false, GlobalSearchScope.allScope(project))
+         .mapNotNull { it.toPsiFile(project) }
+         .flatMap { it.detectKotestTags() }
+         .distinct()
+         .sorted()
+   }
+}

--- a/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/toolbar.kt
+++ b/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/toolbar.kt
@@ -37,19 +37,19 @@ private fun createActionGroup(tree: TestFileTree, project: Project): DefaultActi
    return result
 }
 
-class CollapseAction(private val tree: TestFileTree) : AnAction("Collapse all", null, AllIcons.Actions.Collapseall) {
+class CollapseAction(private val tree: TestFileTree) : AnAction("Collapse All", null, AllIcons.Actions.Collapseall) {
    override fun actionPerformed(e: AnActionEvent) {
       tree.collapseTopLevelNodes()
    }
 }
 
-class ExpandAllAction(private val tree: TestFileTree) : AnAction("Expand all", null, AllIcons.Actions.Expandall) {
+class ExpandAllAction(private val tree: TestFileTree) : AnAction("Expand All", null, AllIcons.Actions.Expandall) {
    override fun actionPerformed(e: AnActionEvent) {
       tree.expandAllNodes()
    }
 }
 
-class FilterCallbacksAction(private val tree: TestFileTree) : ToggleAction("Filter callbacks", null, AllIcons.Nodes.Controller) {
+class FilterCallbacksAction(private val tree: TestFileTree) : ToggleAction("Filter Vallbacks", null, AllIcons.Nodes.Controller) {
 
    override fun isSelected(e: AnActionEvent): Boolean {
       return TestExplorerState.showCallbacks
@@ -61,7 +61,7 @@ class FilterCallbacksAction(private val tree: TestFileTree) : ToggleAction("Filt
    }
 }
 
-class FilterModulesAction(private val tree: TestFileTree) : ToggleAction("Filter modules", null, AllIcons.Nodes.ModuleGroup) {
+class FilterModulesAction(private val tree: TestFileTree) : ToggleAction("Filter Modules", null, AllIcons.Nodes.ModuleGroup) {
 
    override fun isSelected(e: AnActionEvent): Boolean {
       return TestExplorerState.showModules
@@ -73,7 +73,7 @@ class FilterModulesAction(private val tree: TestFileTree) : ToggleAction("Filter
    }
 }
 
-class FilterIncludesAction(private val tree: TestFileTree) : ToggleAction("Filter includes", null, AllIcons.Nodes.Tag) {
+class FilterIncludesAction(private val tree: TestFileTree) : ToggleAction("Filter Includes", null, AllIcons.Nodes.Tag) {
 
    override fun isSelected(e: AnActionEvent): Boolean {
       return TestExplorerState.showIncludes
@@ -86,7 +86,7 @@ class FilterIncludesAction(private val tree: TestFileTree) : ToggleAction("Filte
 }
 
 class NavigateToNodeAction : ToggleAction(
-   "Autoscroll to source",
+   "Autoscroll To Source",
    null,
    AllIcons.General.AutoscrollToSource) {
 

--- a/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/toolbar.kt
+++ b/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/toolbar.kt
@@ -32,6 +32,7 @@ private fun createActionGroup(tree: TestFileTree, project: Project): DefaultActi
    result.add(FilterCallbacksAction(tree))
    result.add(FilterIncludesAction(tree))
    result.add(FilterModulesAction(tree))
+   result.add(FilterTagsAction(tree))
    result.addSeparator()
    result.add(NavigateToNodeAction())
    return result
@@ -49,7 +50,8 @@ class ExpandAllAction(private val tree: TestFileTree) : AnAction("Expand All", n
    }
 }
 
-class FilterCallbacksAction(private val tree: TestFileTree) : ToggleAction("Filter Vallbacks", null, AllIcons.Nodes.Controller) {
+class FilterCallbacksAction(private val tree: TestFileTree) :
+   ToggleAction("Filter Vallbacks", null, AllIcons.Nodes.Controller) {
 
    override fun isSelected(e: AnActionEvent): Boolean {
       return TestExplorerState.showCallbacks
@@ -61,7 +63,8 @@ class FilterCallbacksAction(private val tree: TestFileTree) : ToggleAction("Filt
    }
 }
 
-class FilterModulesAction(private val tree: TestFileTree) : ToggleAction("Filter Modules", null, AllIcons.Nodes.ModuleGroup) {
+class FilterModulesAction(private val tree: TestFileTree) :
+   ToggleAction("Filter Modules", null, AllIcons.Nodes.ModuleGroup) {
 
    override fun isSelected(e: AnActionEvent): Boolean {
       return TestExplorerState.showModules
@@ -69,6 +72,18 @@ class FilterModulesAction(private val tree: TestFileTree) : ToggleAction("Filter
 
    override fun setSelected(e: AnActionEvent, state: Boolean) {
       TestExplorerState.showModules = state
+      tree.reloadModel()
+   }
+}
+
+class FilterTagsAction(private val tree: TestFileTree) : ToggleAction("Filter Tags", null, AllIcons.Nodes.Tag) {
+
+   override fun isSelected(e: AnActionEvent): Boolean {
+      return TestExplorerState.showTags
+   }
+
+   override fun setSelected(e: AnActionEvent, state: Boolean) {
+      TestExplorerState.showTags = state
       tree.reloadModel()
    }
 }
@@ -88,7 +103,8 @@ class FilterIncludesAction(private val tree: TestFileTree) : ToggleAction("Filte
 class NavigateToNodeAction : ToggleAction(
    "Autoscroll To Source",
    null,
-   AllIcons.General.AutoscrollToSource) {
+   AllIcons.General.AutoscrollToSource
+) {
 
    override fun isSelected(e: AnActionEvent): Boolean {
       return TestExplorerState.autoscrollToSource

--- a/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/treeModel.kt
+++ b/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/treeModel.kt
@@ -20,18 +20,22 @@ import javax.swing.tree.TreeModel
 /**
  * Creates a [TreeModel] for the given [VirtualFile].
  */
-fun createTreeModel(file: VirtualFile,
-                    project: Project,
-                    specs: List<KtClassOrObject>,
-                    module: Module): TreeModel {
+fun createTreeModel(
+   file: VirtualFile,
+   project: Project,
+   specs: List<KtClassOrObject>,
+   module: Module
+): TreeModel {
 
    val kotest = KotestRootNodeDescriptor(project)
    val root = DefaultMutableTreeNode(kotest)
 
-   fun addTests(node: DefaultMutableTreeNode,
-                parent: NodeDescriptor<Any>,
-                specDescriptor: SpecNodeDescriptor,
-                tests: List<TestElement>) {
+   fun addTests(
+      node: DefaultMutableTreeNode,
+      parent: NodeDescriptor<Any>,
+      specDescriptor: SpecNodeDescriptor,
+      tests: List<TestElement>
+   ) {
 
       val groups = tests.groupBy { it.test.name }
 
@@ -58,6 +62,19 @@ fun createTreeModel(file: VirtualFile,
             val moduleNode = DefaultMutableTreeNode(moduleDescriptor)
             allModulesNode.add(moduleNode)
          }
+   }
+
+   if (TestExplorerState.showTags) {
+
+      val descriptor = TagsNodeDescriptor(project)
+      val node = DefaultMutableTreeNode(descriptor)
+      root.add(node)
+
+      TestExplorerState.tags.forEach {
+         val tagDescriptor = TagNodeDescriptor(it, project, descriptor)
+         val tagNode = DefaultMutableTreeNode(tagDescriptor)
+         node.add(tagNode)
+      }
    }
 
    val fileDescriptor = TestFileNodeDescriptor(file, project, kotest)
@@ -103,5 +120,6 @@ fun createTreeModel(file: VirtualFile,
 fun Module.isKotlin(): Boolean = FacetManager.getInstance(this).allFacets.filterIsInstance<KotlinFacet>().isNotEmpty()
 
 fun Module.isTestModule(): Boolean {
-   return FacetManager.getInstance(this).allFacets.filterIsInstance<KotlinFacet>().any { it.configuration.settings.isTestModule }
+   return FacetManager.getInstance(this).allFacets.filterIsInstance<KotlinFacet>()
+      .any { it.configuration.settings.isTestModule }
 }

--- a/src/test/kotlin/io/kotest/plugin/intellij/styles/TreeModelTest.kt
+++ b/src/test/kotlin/io/kotest/plugin/intellij/styles/TreeModelTest.kt
@@ -11,6 +11,7 @@ import io.kotest.plugin.intellij.toolwindow.IncludeNodeDescriptor
 import io.kotest.plugin.intellij.toolwindow.KotestRootNodeDescriptor
 import io.kotest.plugin.intellij.toolwindow.ModulesNodeDescriptor
 import io.kotest.plugin.intellij.toolwindow.SpecNodeDescriptor
+import io.kotest.plugin.intellij.toolwindow.TagsNodeDescriptor
 import io.kotest.plugin.intellij.toolwindow.TestFileNodeDescriptor
 import io.kotest.plugin.intellij.toolwindow.TestNodeDescriptor
 import io.kotest.plugin.intellij.toolwindow.createTreeModel
@@ -44,7 +45,9 @@ class TreeModelTest : LightJavaCodeInsightFixtureTestCase() {
       children.size shouldBe 2
       children[0].userObject.shouldBeInstanceOf<ModulesNodeDescriptor>()
 
-      val testfile = children[1]
+      children[1].userObject.shouldBeInstanceOf<TagsNodeDescriptor>()
+
+      val testfile = children[2]
       testfile.userObject.shouldBeInstanceOf<TestFileNodeDescriptor>()
 
       val specs = testfile.children().toList() as List<DefaultMutableTreeNode>

--- a/src/test/kotlin/io/kotest/plugin/intellij/styles/TreeModelTest.kt
+++ b/src/test/kotlin/io/kotest/plugin/intellij/styles/TreeModelTest.kt
@@ -3,9 +3,17 @@ package io.kotest.plugin.intellij.styles
 import com.intellij.testFramework.LightProjectDescriptor
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.kotest.plugin.intellij.Constants
 import io.kotest.plugin.intellij.psi.specs
+import io.kotest.plugin.intellij.toolwindow.CallbackNodeDescriptor
+import io.kotest.plugin.intellij.toolwindow.IncludeNodeDescriptor
 import io.kotest.plugin.intellij.toolwindow.KotestRootNodeDescriptor
+import io.kotest.plugin.intellij.toolwindow.ModulesNodeDescriptor
+import io.kotest.plugin.intellij.toolwindow.SpecNodeDescriptor
+import io.kotest.plugin.intellij.toolwindow.TagsNodeDescriptor
+import io.kotest.plugin.intellij.toolwindow.TestFileNodeDescriptor
+import io.kotest.plugin.intellij.toolwindow.TestNodeDescriptor
 import io.kotest.plugin.intellij.toolwindow.createTreeModel
 import java.nio.file.Paths
 import javax.swing.tree.DefaultMutableTreeNode

--- a/src/test/kotlin/io/kotest/plugin/intellij/styles/TreeModelTest.kt
+++ b/src/test/kotlin/io/kotest/plugin/intellij/styles/TreeModelTest.kt
@@ -37,13 +37,13 @@ class TreeModelTest : LightJavaCodeInsightFixtureTestCase() {
 
       val model = createTreeModel(myFixture.file.virtualFile, myFixture.project, myFixture.file.specs(), myFixture.module)
 
-      val root = model.root as DefaultMutableTreeNode
-      val kotest = root.userObject as KotestRootNodeDescriptor
-      kotest.presentation.presentableText shouldBe Constants.FrameworkName
-
-      val children = root.children().toList() as List<DefaultMutableTreeNode>
-      children.size shouldBe 2
-      children[0].userObject.shouldBeInstanceOf<ModulesNodeDescriptor>()
+//      val root = model.root as DefaultMutableTreeNode
+//      val kotest = root.userObject as KotestRootNodeDescriptor
+//      kotest.presentation.presentableText shouldBe Constants.FrameworkName
+//
+//      val children = root.children().toList() as List<DefaultMutableTreeNode>
+//      children.size shouldBe 2
+//      children[0].userObject.shouldBeInstanceOf<ModulesNodeDescriptor>()
 
 //      children[1].userObject.shouldBeInstanceOf<TagsNodeDescriptor>()
 //

--- a/src/test/kotlin/io/kotest/plugin/intellij/styles/TreeModelTest.kt
+++ b/src/test/kotlin/io/kotest/plugin/intellij/styles/TreeModelTest.kt
@@ -35,7 +35,7 @@ class TreeModelTest : LightJavaCodeInsightFixtureTestCase() {
          "/io/kotest/core/spec/style/specs.kt"
       )
 
-      val model = createTreeModel(myFixture.file.virtualFile, myFixture.project, myFixture.file.specs(), myFixture.module)
+//      val model = createTreeModel(myFixture.file.virtualFile, myFixture.project, myFixture.file.specs(), myFixture.module)
 
 //      val root = model.root as DefaultMutableTreeNode
 //      val kotest = root.userObject as KotestRootNodeDescriptor

--- a/src/test/kotlin/io/kotest/plugin/intellij/styles/TreeModelTest.kt
+++ b/src/test/kotlin/io/kotest/plugin/intellij/styles/TreeModelTest.kt
@@ -3,17 +3,9 @@ package io.kotest.plugin.intellij.styles
 import com.intellij.testFramework.LightProjectDescriptor
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.types.shouldBeInstanceOf
 import io.kotest.plugin.intellij.Constants
 import io.kotest.plugin.intellij.psi.specs
-import io.kotest.plugin.intellij.toolwindow.CallbackNodeDescriptor
-import io.kotest.plugin.intellij.toolwindow.IncludeNodeDescriptor
 import io.kotest.plugin.intellij.toolwindow.KotestRootNodeDescriptor
-import io.kotest.plugin.intellij.toolwindow.ModulesNodeDescriptor
-import io.kotest.plugin.intellij.toolwindow.SpecNodeDescriptor
-import io.kotest.plugin.intellij.toolwindow.TagsNodeDescriptor
-import io.kotest.plugin.intellij.toolwindow.TestFileNodeDescriptor
-import io.kotest.plugin.intellij.toolwindow.TestNodeDescriptor
 import io.kotest.plugin.intellij.toolwindow.createTreeModel
 import java.nio.file.Paths
 import javax.swing.tree.DefaultMutableTreeNode
@@ -35,11 +27,12 @@ class TreeModelTest : LightJavaCodeInsightFixtureTestCase() {
          "/io/kotest/core/spec/style/specs.kt"
       )
 
-//      val model = createTreeModel(myFixture.file.virtualFile, myFixture.project, myFixture.file.specs(), myFixture.module)
+      val model =
+         createTreeModel(myFixture.file.virtualFile, myFixture.project, myFixture.file.specs(), myFixture.module)
 
-//      val root = model.root as DefaultMutableTreeNode
-//      val kotest = root.userObject as KotestRootNodeDescriptor
-//      kotest.presentation.presentableText shouldBe Constants.FrameworkName
+      val root = model.root as DefaultMutableTreeNode
+      val kotest = root.userObject as KotestRootNodeDescriptor
+      kotest.presentation.presentableText shouldBe Constants.FrameworkName
 //
 //      val children = root.children().toList() as List<DefaultMutableTreeNode>
 //      children.size shouldBe 2

--- a/src/test/kotlin/io/kotest/plugin/intellij/styles/TreeModelTest.kt
+++ b/src/test/kotlin/io/kotest/plugin/intellij/styles/TreeModelTest.kt
@@ -45,23 +45,23 @@ class TreeModelTest : LightJavaCodeInsightFixtureTestCase() {
       children.size shouldBe 2
       children[0].userObject.shouldBeInstanceOf<ModulesNodeDescriptor>()
 
-      children[1].userObject.shouldBeInstanceOf<TagsNodeDescriptor>()
-
-      val testfile = children[2]
-      testfile.userObject.shouldBeInstanceOf<TestFileNodeDescriptor>()
-
-      val specs = testfile.children().toList() as List<DefaultMutableTreeNode>
-      specs.size shouldBe 1
-      val spec = specs[0]
-      spec.userObject.shouldBeInstanceOf<SpecNodeDescriptor>()
-
-      val elements = spec.children().toList() as List<DefaultMutableTreeNode>
-      elements.size shouldBe 5
-
-      (elements[0].userObject as CallbackNodeDescriptor).presentation.presentableText shouldBe "beforeTest"
-      (elements[1].userObject as CallbackNodeDescriptor).presentation.presentableText shouldBe "afterTest"
-      (elements[2].userObject as IncludeNodeDescriptor).presentation.presentableText shouldBe "Include: myfactory"
-      (elements[3].userObject as IncludeNodeDescriptor).presentation.presentableText shouldBe "Include: myfactory2"
-      (elements[4].userObject as TestNodeDescriptor).presentation.presentableText shouldBe "a string cannot be blank"
+//      children[1].userObject.shouldBeInstanceOf<TagsNodeDescriptor>()
+//
+//      val testfile = children[2]
+//      testfile.userObject.shouldBeInstanceOf<TestFileNodeDescriptor>()
+//
+//      val specs = testfile.children().toList() as List<DefaultMutableTreeNode>
+//      specs.size shouldBe 1
+//      val spec = specs[0]
+//      spec.userObject.shouldBeInstanceOf<SpecNodeDescriptor>()
+//
+//      val elements = spec.children().toList() as List<DefaultMutableTreeNode>
+//      elements.size shouldBe 5
+//
+//      (elements[0].userObject as CallbackNodeDescriptor).presentation.presentableText shouldBe "beforeTest"
+//      (elements[1].userObject as CallbackNodeDescriptor).presentation.presentableText shouldBe "afterTest"
+//      (elements[2].userObject as IncludeNodeDescriptor).presentation.presentableText shouldBe "Include: myfactory"
+//      (elements[3].userObject as IncludeNodeDescriptor).presentation.presentableText shouldBe "Include: myfactory2"
+//      (elements[4].userObject as TestNodeDescriptor).presentation.presentableText shouldBe "a string cannot be blank"
    }
 }

--- a/src/test/kotlin/io/kotest/plugin/intellij/styles/TreeModelTest.kt
+++ b/src/test/kotlin/io/kotest/plugin/intellij/styles/TreeModelTest.kt
@@ -33,28 +33,28 @@ class TreeModelTest : LightJavaCodeInsightFixtureTestCase() {
       val root = model.root as DefaultMutableTreeNode
       val kotest = root.userObject as KotestRootNodeDescriptor
       kotest.presentation.presentableText shouldBe Constants.FrameworkName
-//
-//      val children = root.children().toList() as List<DefaultMutableTreeNode>
-//      children.size shouldBe 2
-//      children[0].userObject.shouldBeInstanceOf<ModulesNodeDescriptor>()
 
-//      children[1].userObject.shouldBeInstanceOf<TagsNodeDescriptor>()
-//
-//      val testfile = children[2]
-//      testfile.userObject.shouldBeInstanceOf<TestFileNodeDescriptor>()
-//
-//      val specs = testfile.children().toList() as List<DefaultMutableTreeNode>
-//      specs.size shouldBe 1
-//      val spec = specs[0]
-//      spec.userObject.shouldBeInstanceOf<SpecNodeDescriptor>()
-//
-//      val elements = spec.children().toList() as List<DefaultMutableTreeNode>
-//      elements.size shouldBe 5
-//
-//      (elements[0].userObject as CallbackNodeDescriptor).presentation.presentableText shouldBe "beforeTest"
-//      (elements[1].userObject as CallbackNodeDescriptor).presentation.presentableText shouldBe "afterTest"
-//      (elements[2].userObject as IncludeNodeDescriptor).presentation.presentableText shouldBe "Include: myfactory"
-//      (elements[3].userObject as IncludeNodeDescriptor).presentation.presentableText shouldBe "Include: myfactory2"
-//      (elements[4].userObject as TestNodeDescriptor).presentation.presentableText shouldBe "a string cannot be blank"
+      val children = root.children().toList() as List<DefaultMutableTreeNode>
+      children.size shouldBe 3
+      children[0].userObject.shouldBeInstanceOf<ModulesNodeDescriptor>()
+
+      children[1].userObject.shouldBeInstanceOf<TagsNodeDescriptor>()
+
+      val testfile = children[2]
+      testfile.userObject.shouldBeInstanceOf<TestFileNodeDescriptor>()
+
+      val specs = testfile.children().toList() as List<DefaultMutableTreeNode>
+      specs.size shouldBe 1
+      val spec = specs[0]
+      spec.userObject.shouldBeInstanceOf<SpecNodeDescriptor>()
+
+      val elements = spec.children().toList() as List<DefaultMutableTreeNode>
+      elements.size shouldBe 5
+
+      (elements[0].userObject as CallbackNodeDescriptor).presentation.presentableText shouldBe "beforeTest"
+      (elements[1].userObject as CallbackNodeDescriptor).presentation.presentableText shouldBe "afterTest"
+      (elements[2].userObject as IncludeNodeDescriptor).presentation.presentableText shouldBe "Include: myfactory"
+      (elements[3].userObject as IncludeNodeDescriptor).presentation.presentableText shouldBe "Include: myfactory2"
+      (elements[4].userObject as TestNodeDescriptor).presentation.presentableText shouldBe "a string cannot be blank"
    }
 }


### PR DESCRIPTION
Adds new window which scans for tags defined in files named KotestTags.kt

![image](https://user-images.githubusercontent.com/743706/180692445-f05d664c-c46f-41ab-9f2a-3f6dcdccfd11.png)

Next step will be to execute tests with those tags when you double click. We may need our (in the works) gradle plugin for that though.