### PR TITLE
add JsonPath language injection for JsonPath assertions

### DIFF
--- a/src/IC-222/resources/META-INF/plugin.xml
+++ b/src/IC-222/resources/META-INF/plugin.xml
@@ -17,6 +17,7 @@
    <depends>org.jetbrains.kotlin</depends>
    <depends>com.intellij.modules.java</depends>
    <depends>org.jetbrains.plugins.gradle</depends>
+   <depends optional="true" config-file="intellilang-kotlin-support.xml">org.intellij.intelliLang</depends>
 
    <actions>
       <action id="io.kotest.actions.NextTestAction"

--- a/src/main/resources/META-INF/intellilang-kotlin-support.xml
+++ b/src/main/resources/META-INF/intellilang-kotlin-support.xml
@@ -1,6 +1,5 @@
 <idea-plugin>
    <extensions defaultExtensionNs="org.intellij.intelliLang">
-      <languageSupport implementation="org.intellij.plugins.intelliLang.inject.java.JavaLanguageInjectionSupport"/>
       <injectionConfig config="injections/kotlinInjections.xml"/>
    </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/intellilang-kotlin-support.xml
+++ b/src/main/resources/META-INF/intellilang-kotlin-support.xml
@@ -1,0 +1,6 @@
+<idea-plugin>
+   <extensions defaultExtensionNs="org.intellij.intelliLang">
+      <languageSupport implementation="org.intellij.plugins.intelliLang.inject.java.JavaLanguageInjectionSupport"/>
+      <injectionConfig config="injections/kotlinInjections.xml"/>
+   </extensions>
+</idea-plugin>

--- a/src/main/resources/injections/kotlinInjections.xml
+++ b/src/main/resources/injections/kotlinInjections.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component name="LanguageInjectionConfiguration">
-   <injection language="JSON" injector-id="kotlin">
+   <injection language="JSONPath" injector-id="kotlin">
       <display-name>JsonPath (io.kotest.assertions.json)</display-name>
-            <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("shouldContainJsonKey").definedInPackage("io.kotest.assertions.json"))]]></place>
-            <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("shouldNotContainJsonKey").definedInPackage("io.kotest.assertions.json"))]]></place>
-            <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("containJsonKey").definedInPackage("io.kotest.assertions.json"))]]></place>
+         <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("shouldContainJsonKey").definedInPackage("io.kotest.assertions.json"))]]></place>
+         <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("shouldNotContainJsonKey").definedInPackage("io.kotest.assertions.json"))]]></place>
+         <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("containJsonKey").definedInPackage("io.kotest.assertions.json"))]]></place>
 
-            <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("shouldContainJsonKeyValue").definedInPackage("io.kotest.assertions.json"))]]></place>
-            <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("shouldNotContainJsonKeyValue").definedInPackage("io.kotest.assertions.json"))]]></place>
-            <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("containJsonKeyValue").definedInPackage("io.kotest.assertions.json"))]]></place>
+         <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("shouldContainJsonKeyValue").definedInPackage("io.kotest.assertions.json"))]]></place>
+         <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("shouldNotContainJsonKeyValue").definedInPackage("io.kotest.assertions.json"))]]></place>
+         <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("containJsonKeyValue").definedInPackage("io.kotest.assertions.json"))]]></place>
 
-            <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("shouldMatchJsonResource").definedInPackage("io.kotest.assertions.json"))]]></place>
-            <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("shouldNotMatchJsonResource").definedInPackage("io.kotest.assertions.json"))]]></place>
-            <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("matchJsonResource").definedInPackage("io.kotest.assertions.json"))]]></place>
+         <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("shouldMatchJsonResource").definedInPackage("io.kotest.assertions.json"))]]></place>
+         <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("shouldNotMatchJsonResource").definedInPackage("io.kotest.assertions.json"))]]></place>
+         <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("matchJsonResource").definedInPackage("io.kotest.assertions.json"))]]></place>
    </injection>
 </component>

--- a/src/main/resources/injections/kotlinInjections.xml
+++ b/src/main/resources/injections/kotlinInjections.xml
@@ -9,9 +9,5 @@
          <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("shouldContainJsonKeyValue").definedInPackage("io.kotest.assertions.json"))]]></place>
          <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("shouldNotContainJsonKeyValue").definedInPackage("io.kotest.assertions.json"))]]></place>
          <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("containJsonKeyValue").definedInPackage("io.kotest.assertions.json"))]]></place>
-
-         <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("shouldMatchJsonResource").definedInPackage("io.kotest.assertions.json"))]]></place>
-         <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("shouldNotMatchJsonResource").definedInPackage("io.kotest.assertions.json"))]]></place>
-         <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("matchJsonResource").definedInPackage("io.kotest.assertions.json"))]]></place>
    </injection>
 </component>

--- a/src/main/resources/injections/kotlinInjections.xml
+++ b/src/main/resources/injections/kotlinInjections.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component name="LanguageInjectionConfiguration">
+   <injection language="JSON" injector-id="kotlin">
+      <display-name>JsonPath (io.kotest.assertions.json)</display-name>
+            <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("shouldContainJsonKey").definedInPackage("io.kotest.assertions.json"))]]></place>
+            <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("shouldNotContainJsonKey").definedInPackage("io.kotest.assertions.json"))]]></place>
+            <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("containJsonKey").definedInPackage("io.kotest.assertions.json"))]]></place>
+
+            <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("shouldContainJsonKeyValue").definedInPackage("io.kotest.assertions.json"))]]></place>
+            <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("shouldNotContainJsonKeyValue").definedInPackage("io.kotest.assertions.json"))]]></place>
+            <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("containJsonKeyValue").definedInPackage("io.kotest.assertions.json"))]]></place>
+
+            <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("shouldMatchJsonResource").definedInPackage("io.kotest.assertions.json"))]]></place>
+            <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("shouldNotMatchJsonResource").definedInPackage("io.kotest.assertions.json"))]]></place>
+            <place><![CDATA[kotlinParameter().ofFunction(0, kotlinFunction().withName("matchJsonResource").definedInPackage("io.kotest.assertions.json"))]]></place>
+   </injection>
+</component>


### PR DESCRIPTION
Resolves #217 
Resolves https://github.com/kotest/kotest/issues/2916

I have quickly manually tested this in a JVM project, and it works as expected

<img width="929" alt="image" src="https://user-images.githubusercontent.com/897017/192087491-ed8235ce-5338-4b86-897d-874048c125ca.png">

It even automatically add some auto-complete hints, which is more than I expected!

I'm not sure if automated tests are possible, or how to do them.