### PR TITLE
Create test tree module by programmatically identifying test modules

### DIFF
--- a/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/treeModel.kt
+++ b/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/treeModel.kt
@@ -10,6 +10,7 @@ import io.kotest.plugin.intellij.fqname
 import io.kotest.plugin.intellij.psi.callbacks
 import io.kotest.plugin.intellij.psi.includes
 import io.kotest.plugin.intellij.psi.specStyle
+import org.jetbrains.kotlin.idea.base.facet.isTestModule
 import org.jetbrains.kotlin.idea.facet.KotlinFacet
 import org.jetbrains.kotlin.idea.util.projectStructure.allModules
 import org.jetbrains.kotlin.psi.KtClassOrObject
@@ -56,7 +57,7 @@ fun createTreeModel(
 
       project.allModules()
          .filter { it.isKotlin() }
-         .filter { it.name.endsWith("jvmTest") || it.name.endsWith("test") }
+         .filter { it.isTestModule }
          .forEach {
             val moduleDescriptor = ModuleNodeDescriptor(it, project, allModulesDescriptor)
             val moduleNode = DefaultMutableTreeNode(moduleDescriptor)


### PR DESCRIPTION
An attempt to resolve https://github.com/kotest/kotest-intellij-plugin/issues/266.

I am actually not sure if this resolves the original issue. I tried the snapshot of the plugin locally and it did not help. This seems like a good change to have nonetheless?

I also tried to run unit tests locally to make sure they pass but ran into `./gradlew test`:

```
PluginException: Trying to add extensions to non-registered file type Properties [Plugin: com.intellij.java]
```