### PR TITLE
Adding Live Templates

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -37,6 +37,7 @@
 
    <extensions defaultExtensionNs="com.intellij">
       <configurationType implementation="io.kotest.plugin.intellij.KotestConfigurationType"/>
+      <defaultLiveTemplates file="liveTemplates.xml" />
 
       <annotator language="kotlin"
                  implementationClass="io.kotest.plugin.intellij.annotators.DuplicatedTestNameAnnotator"/>

--- a/src/main/resources/liveTemplates.xml
+++ b/src/main/resources/liveTemplates.xml
@@ -1,0 +1,34 @@
+<templateSet group="Kotest">
+   <template name="bspec"
+             value="class $SPEC$: io.kotest.core.spec.style.BehaviorSpec({&#10;    Given(&quot;$FIRST_TEST$&quot;) {&#10;        When(&quot;$first_when$&quot;) {&#10;            Then(&quot;$then$&quot;) {&#10;                $FIRST_TEST_CONTENT$&#10;            }&#10;        }  &#10;    }&#10;})"
+             description="Creates a new BehaviorSpec" toReformat="false" toShortenFQNames="true">
+      <variable name="SPEC" expression="" defaultValue="fileNameWithoutExtension()" alwaysStopAt="true"/>
+      <variable name="FIRST_TEST" expression="" defaultValue="&quot;foo&quot;" alwaysStopAt="true"/>
+      <variable name="first_when" expression="" defaultValue="&quot;bar&quot;" alwaysStopAt="true"/>
+      <variable name="then" expression="" defaultValue="&quot;baz&quot;" alwaysStopAt="true"/>
+      <variable name="FIRST_TEST_CONTENT" expression="" defaultValue="&quot;1 shouldBe 1&quot;" alwaysStopAt="true"/>
+      <context>
+         <option name="KOTLIN_TOPLEVEL" value="true"/>
+      </context>
+   </template>
+   <template name="fspec"
+             value="class $SPEC$: io.kotest.core.spec.style.FunSpec({&#10;    test(&quot;$FIRST_TEST$&quot;) {&#10;        $FIRST_TEST_CONTENT$  &#10;    }&#10;})"
+             description="Creates a new FunSpec" toReformat="false" toShortenFQNames="true">
+      <variable name="SPEC" expression="" defaultValue="fileNameWithoutExtension()" alwaysStopAt="true"/>
+      <variable name="FIRST_TEST" expression="" defaultValue="&quot;Foo&quot;" alwaysStopAt="true"/>
+      <variable name="FIRST_TEST_CONTENT" expression="" defaultValue="&quot;1 shouldBe 1&quot;" alwaysStopAt="true"/>
+      <context>
+         <option name="KOTLIN_TOPLEVEL" value="true"/>
+      </context>
+   </template>
+   <template name="sspec"
+             value="class $SPEC$: io.kotest.core.spec.style.StringSpec({&#10;    &quot;$FIRST_TEST$&quot; {&#10;        $FIRST_TEST_CONTENT$  &#10;    }&#10;})"
+             description="Creates a new StringSpec" toReformat="false" toShortenFQNames="true">
+      <variable name="SPEC" expression="" defaultValue="fileNameWithoutExtension()" alwaysStopAt="true"/>
+      <variable name="FIRST_TEST" expression="" defaultValue="&quot;Foo&quot;" alwaysStopAt="true"/>
+      <variable name="FIRST_TEST_CONTENT" expression="" defaultValue="&quot;1 shouldBe 1&quot;" alwaysStopAt="true"/>
+      <context>
+         <option name="KOTLIN_TOPLEVEL" value="true"/>
+      </context>
+   </template>
+</templateSet>

--- a/src/main/resources/liveTemplates.xml
+++ b/src/main/resources/liveTemplates.xml
@@ -1,5 +1,5 @@
 <templateSet group="Kotest">
-   <template name="bspec"
+   <template name="behaviorspec"
              value="class $SPEC$: io.kotest.core.spec.style.BehaviorSpec({&#10;    Given(&quot;$FIRST_TEST$&quot;) {&#10;        When(&quot;$first_when$&quot;) {&#10;            Then(&quot;$then$&quot;) {&#10;                $FIRST_TEST_CONTENT$&#10;            }&#10;        }  &#10;    }&#10;})"
              description="Creates a new BehaviorSpec" toReformat="false" toShortenFQNames="true">
       <variable name="SPEC" expression="" defaultValue="fileNameWithoutExtension()" alwaysStopAt="true"/>
@@ -11,7 +11,7 @@
          <option name="KOTLIN_TOPLEVEL" value="true"/>
       </context>
    </template>
-   <template name="fspec"
+   <template name="funspec"
              value="class $SPEC$: io.kotest.core.spec.style.FunSpec({&#10;    test(&quot;$FIRST_TEST$&quot;) {&#10;        $FIRST_TEST_CONTENT$  &#10;    }&#10;})"
              description="Creates a new FunSpec" toReformat="false" toShortenFQNames="true">
       <variable name="SPEC" expression="" defaultValue="fileNameWithoutExtension()" alwaysStopAt="true"/>
@@ -21,7 +21,7 @@
          <option name="KOTLIN_TOPLEVEL" value="true"/>
       </context>
    </template>
-   <template name="sspec"
+   <template name="stringspec"
              value="class $SPEC$: io.kotest.core.spec.style.StringSpec({&#10;    &quot;$FIRST_TEST$&quot; {&#10;        $FIRST_TEST_CONTENT$  &#10;    }&#10;})"
              description="Creates a new StringSpec" toReformat="false" toShortenFQNames="true">
       <variable name="SPEC" expression="" defaultValue="fileNameWithoutExtension()" alwaysStopAt="true"/>


### PR DESCRIPTION
When a user wants to define a new spec, they can:
1. Create a **Kotlin file** (Not class) in the desired location, with the name of the spec they want to define.
2. In the opened file, use one of the provided live templates. For instance `fspec` to start defining a FunSpec

`fspec` expands into:
```kotlin
class MyTest : FunSpec({
   test("Foo") {
      1 shouldBe 1
   }
}
```

Where `MyTest` is based on the name of the file, and is the first focused location which lets the user change the Spec name if desired. Pressing tab moves the focus to the name of the test (`Foo`). The user can change the name then press tab again to focus the test body.

IntelliJ also added an import for FunSpec automatically.

Desired feedback:
---

What spec styles and abbreviations should we use?

So far I have added:
* `sspec` -> StringSpec
  * Perhaps FreeSpec is a better spec to focus on, given that it supports nesting. But I think we might harmonize them and settle on a final name for this style
* `bspec` -> BehaviorSpec
* `fspec` -> FunSpec
  * This one clashes a bit with FreeSpec and FeatureSpec

Maybe we can dogfood this one in the wild.. not a lot of users would find the feature w/o us advertising it somewhere.