### PR TITLE
Fix navigation to test on click

### DIFF
--- a/src/main/kotlin/io/kotest/plugin/intellij/KotestTestFinder.kt
+++ b/src/main/kotlin/io/kotest/plugin/intellij/KotestTestFinder.kt
@@ -38,8 +38,8 @@ class KotestTestFinder : TestFinder {
    }
 
    /**
-    * This is used by the navivation menu to determine if it should show "navigate to tests" or
-    * "nagivate to test subjects". Depending on the response, [findClassesForTest] or
+    * This is used by the navigation menu to determine if it should show "navigate to tests" or
+    * "navigate to test subjects". Depending on the response, [findClassesForTest] or
     * [findTestsForClass] will be called.
     */
    override fun isTest(element: PsiElement): Boolean = element.isContainedInSpec()

--- a/src/main/kotlin/io/kotest/plugin/intellij/psi/offsets.kt
+++ b/src/main/kotlin/io/kotest/plugin/intellij/psi/offsets.kt
@@ -19,6 +19,19 @@ fun PsiFile.offsetForLine(line: Int): IntRange? {
    }
 }
 
+fun PsiFile.offsetForTestLine(line: Int): Int? {
+   val doc = PsiDocumentManager.getInstance(project).getDocument(this) ?: return null
+   return try {
+      doc.getLineStartOffset(line)
+   } catch (e: Exception) {
+      null
+   }
+}
+
+fun PsiFile.findTestElementAtLine(line: Int): PsiElement?  {
+   return offsetForTestLine(line)?.let { findElementAt(it) }
+}
+
 /**
  * Finds the first [PsiElement] for the given offset range by iterating over
  * the values in the range until an element is found.
@@ -26,7 +39,7 @@ fun PsiFile.offsetForLine(line: Int): IntRange? {
 fun PsiElement.findElementInRange(offsets: IntRange): PsiElement? {
    return offsets.asSequence()
       .mapNotNull { findElementAt(it) }
-      .firstOrNull()
+      .elementAtOrNull(1)
 }
 
 /**
@@ -35,7 +48,14 @@ fun PsiElement.findElementInRange(offsets: IntRange): PsiElement? {
  *
  * Note: This method is 1 indexed.
  */
-fun PsiFile.elementAtLine(line: Int): PsiElement? =
-   offsetForLine(line)?.let { findElementInRange(it) }
+fun PsiFile.elementAtLine(line: Int): PsiElement?  {
+   if (line < 1) return null
+
+   return when (line) {
+      1 -> offsetForLine(line)?.let { findElementInRange(it) }
+      else -> findTestElementAtLine(line)
+   }
+}
+
 
 fun PsiElement.toPsiLocation() = PsiLocation(project, this)

--- a/src/main/kotlin/io/kotest/plugin/intellij/psi/offsets.kt
+++ b/src/main/kotlin/io/kotest/plugin/intellij/psi/offsets.kt
@@ -4,6 +4,7 @@ import com.intellij.execution.PsiLocation
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiUtilCore
 
 /**
  * Returns the offsets for the given line in this file, or -1 if the document cannot be loaded for this file.
@@ -19,43 +20,22 @@ fun PsiFile.offsetForLine(line: Int): IntRange? {
    }
 }
 
-fun PsiFile.offsetForTestLine(line: Int): Int? {
-   val doc = PsiDocumentManager.getInstance(project).getDocument(this) ?: return null
-   return try {
-      doc.getLineStartOffset(line)
-   } catch (e: Exception) {
-      null
-   }
-}
-
-fun PsiFile.findTestElementAtLine(line: Int): PsiElement?  {
-   return offsetForTestLine(line)?.let { findElementAt(it) }
-}
-
 /**
  * Finds the first [PsiElement] for the given offset range by iterating over
- * the values in the range until an element is found.
+ * the values in the range until an element that is not a whitespace is found.
  */
 fun PsiElement.findElementInRange(offsets: IntRange): PsiElement? {
    return offsets.asSequence()
-      .mapNotNull { findElementAt(it) }
-      .elementAtOrNull(1)
+      .mapNotNull { offset -> findElementAt(offset)?.takeIf { it.text?.isNotBlank() == true } }
+      .firstOrNull()
 }
-
 /**
  * Returns the first element for the given line in this file,
  * or null if the document cannot be loaded for this file.
  *
  * Note: This method is 1 indexed.
  */
-fun PsiFile.elementAtLine(line: Int): PsiElement?  {
-   if (line < 1) return null
-
-   return when (line) {
-      1 -> offsetForLine(line)?.let { findElementInRange(it) }
-      else -> findTestElementAtLine(line)
-   }
-}
-
+fun PsiFile.elementAtLine(line: Int): PsiElement? =
+   offsetForLine(line)?.let { findElementInRange(it) }
 
 fun PsiElement.toPsiLocation() = PsiLocation(project, this)

--- a/src/test/kotlin/io/kotest/plugin/intellij/psi/OffsetsTest.kt
+++ b/src/test/kotlin/io/kotest/plugin/intellij/psi/OffsetsTest.kt
@@ -29,8 +29,8 @@ class OffsetsTest : LightJavaCodeInsightFixtureTestCase() {
       val psiFile = myFixture.configureByFile("/funspec.kt")
       val element: PsiElement? = psiFile.elementAtLine(24)
       element.shouldNotBeNull()
-      element.node.shouldBeInstanceOf<PsiWhiteSpace>()
-      element.startOffset shouldBe 361
-      element.endOffset shouldBe 369
+      element.node.shouldBeInstanceOf<PsiElement>()
+      element.startOffset shouldBe 369
+      element.endOffset shouldBe 373
    }
 }

--- a/src/test/kotlin/io/kotest/plugin/intellij/psi/SpecTests.kt
+++ b/src/test/kotlin/io/kotest/plugin/intellij/psi/SpecTests.kt
@@ -16,45 +16,6 @@ class SpecTests : LightJavaCodeInsightFixtureTestCase() {
       return path.toString()
    }
 
-   fun testIsContainedInSpecFunSpec() {
-
-      val psiFile = myFixture.configureByFiles(
-         "/funspec.kt",
-         "/io/kotest/core/spec/style/specs.kt"
-      )
-
-      psiFile[0].elementAtLine(3)!!.isContainedInSpec() shouldBe false
-      for (k in 10..40) {
-         psiFile[0].elementAtLine(k)!!.isContainedInSpec() shouldBe true
-      }
-   }
-
-   fun testIsContainedInSpecStringSpec() {
-
-      val psiFile = myFixture.configureByFiles(
-         "/stringspec.kt",
-         "/io/kotest/core/spec/style/specs.kt"
-      )
-
-      psiFile[0].elementAtLine(4)!!.isContainedInSpec() shouldBe false
-      for (k in 7..13) {
-         psiFile[0].elementAtLine(k)!!.isContainedInSpec() shouldBe true
-      }
-   }
-
-   fun testIsContainedInSpecFreeSpec() {
-
-      val psiFile = myFixture.configureByFiles(
-         "/freespec.kt",
-         "/io/kotest/core/spec/style/specs.kt"
-      )
-
-      psiFile[0].elementAtLine(4)!!.isContainedInSpec() shouldBe false
-      for (k in 7..21) {
-         psiFile[0].elementAtLine(k)!!.isContainedInSpec() shouldBe true
-      }
-   }
-
    fun testasKtClassOrObjectOrNull() {
 
       val psiFile = myFixture.configureByFiles(


### PR DESCRIPTION
The navigation to tests has been broken for a long time and it has been hampering my productivity a lot. I do not understand whats the point of navigating to an arbitrary white space character that can be anywhere between two tests. 

This is just a simple fix to alleviate that issue. It will navigate to the next non white space character between two tests. Which is a lot better than the current behavior.

Previous behavior: https://jam.dev/c/fa4b7672-a472-4f32-991f-33cd49c79849
Behavior After these changes: https://jam.dev/c/b0551b1b-5d91-4bbb-9d0a-c8e6cc8f843a

Please review this PR. Or suggest me on what tests should I add.