### PR TITLE
feat(toolwindow): speed search

### DIFF
--- a/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/TestFileTree.kt
+++ b/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/TestFileTree.kt
@@ -28,7 +28,7 @@ class TestFileTree(
          val node = path.lastPathComponent as? DefaultMutableTreeNode
          val descriptor = node?.userObject as? PresentableNodeDescriptor<*>
          descriptor?.presentation?.presentableText ?: node?.userObject?.toString() ?: ""
-      }, true)
+      }, false)
       // listens to changes in the selections
       addTreeSelectionListener(testExplorerTreeSelectionListener)
       kotestTestExplorerService.registerModelListener(this)


### PR DESCRIPTION
Use case: when user typing in the tool window it highlights all matches

It is useful when the `*Test` class has a lot of branches. Especially in e2e tests

<img width="823" height="344" alt="Screenshot 2025-08-16 163725" src="https://github.com/user-attachments/assets/8cb00d93-2597-4736-b41b-3326a4c092a6" />
