### PR TITLE
fix(styles): pass Container for describe and context instead of Test

### DIFF
--- a/src/main/kotlin/io/kotest/plugin/intellij/styles/DescribeSpecStyle.kt
+++ b/src/main/kotlin/io/kotest/plugin/intellij/styles/DescribeSpecStyle.kt
@@ -37,7 +37,7 @@ object DescribeSpecStyle : SpecStyle {
             is KtDotQualifiedExpression -> p.tryDescribeWithConfig()
                ?: p.tryXDescribeWithConfig()
                ?: p.tryContextWithConfig()
-               ?: p.tryContextWithConfig()
+               ?: p.tryXContextWithConfig()
             is KtCallExpression -> p.tryDescribe()
                ?: p.tryXDescribe()
                ?: p.tryContext()
@@ -181,7 +181,7 @@ object DescribeSpecStyle : SpecStyle {
          TestName(null, name.text, name.interpolated),
          name.text.startsWith("!"),
          this,
-         TestType.Test,
+         TestType.Container,
          specClass
       )
    }
@@ -199,7 +199,7 @@ object DescribeSpecStyle : SpecStyle {
          TestName(null, name.text, name.interpolated),
          name.text.startsWith("!"),
          this,
-         TestType.Test,
+         TestType.Container,
          specClass
       )
    }
@@ -213,7 +213,7 @@ object DescribeSpecStyle : SpecStyle {
    private fun KtDotQualifiedExpression.tryXDescribeWithConfig(): Test? {
       val specClass = enclosingKtClassOrObject() ?: return null
       val name = extractLhsStringArgForDotExpressionWithRhsFinalLambda("xdescribe", "config") ?: return null
-      return buildTest(TestName(null, name.text, name.interpolated), true, this, TestType.Test, specClass)
+      return buildTest(TestName(null, name.text, name.interpolated), true, this, TestType.Container, specClass)
    }
 
    /**
@@ -225,7 +225,7 @@ object DescribeSpecStyle : SpecStyle {
    private fun KtDotQualifiedExpression.tryXContextWithConfig(): Test? {
       val specClass = enclosingKtClassOrObject() ?: return null
       val name = extractLhsStringArgForDotExpressionWithRhsFinalLambda("xcontext", "config") ?: return null
-      return buildTest(TestName(null, name.text, name.interpolated), true, this, TestType.Test, specClass)
+      return buildTest(TestName(null, name.text, name.interpolated), true, this, TestType.Container, specClass)
    }
 
    private fun buildTest(

--- a/src/main/kotlin/io/kotest/plugin/intellij/styles/FunSpecStyle.kt
+++ b/src/main/kotlin/io/kotest/plugin/intellij/styles/FunSpecStyle.kt
@@ -67,7 +67,7 @@ object FunSpecStyle : SpecStyle {
    private fun KtDotQualifiedExpression.tryContextWithConfig(): Test? {
       val specClass = enclosingKtClassOrObject() ?: return null
       val context = extractLhsStringArgForDotExpressionWithRhsFinalLambda("context", "config") ?: return null
-      return buildTest(TestName(null, context.text, context.interpolated), this, TestType.Test, false, specClass)
+      return buildTest(TestName(null, context.text, context.interpolated), this, TestType.Container, false, specClass)
    }
 
    /**
@@ -79,7 +79,7 @@ object FunSpecStyle : SpecStyle {
    private fun KtDotQualifiedExpression.tryXContextWithConfig(): Test? {
       val specClass = enclosingKtClassOrObject() ?: return null
       val context = extractLhsStringArgForDotExpressionWithRhsFinalLambda("xcontext", "config") ?: return null
-      return buildTest(TestName(null, context.text, context.interpolated), this, TestType.Test, true, specClass)
+      return buildTest(TestName(null, context.text, context.interpolated), this, TestType.Container, true, specClass)
    }
 
    /**

--- a/src/main/kotlin/io/kotest/plugin/intellij/styles/ShouldSpecStyle.kt
+++ b/src/main/kotlin/io/kotest/plugin/intellij/styles/ShouldSpecStyle.kt
@@ -62,7 +62,7 @@ object ShouldSpecStyle : SpecStyle {
    private fun KtDotQualifiedExpression.tryContextWithConfig(): Test? {
       val specClass = enclosingKtClassOrObject() ?: return null
       val context = extractLhsStringArgForDotExpressionWithRhsFinalLambda("context", "config") ?: return null
-      return buildTest(TestName(null, context.text, context.interpolated), this, TestType.Test, false, specClass)
+      return buildTest(TestName(null, context.text, context.interpolated), this, TestType.Container, false, specClass)
    }
 
    /**
@@ -74,7 +74,7 @@ object ShouldSpecStyle : SpecStyle {
    private fun KtDotQualifiedExpression.tryXContextWithConfig(): Test? {
       val specClass = enclosingKtClassOrObject() ?: return null
       val context = extractLhsStringArgForDotExpressionWithRhsFinalLambda("xcontext", "config") ?: return null
-      return buildTest(TestName(null, context.text, context.interpolated), this, TestType.Test, true, specClass)
+      return buildTest(TestName(null, context.text, context.interpolated), this, TestType.Container, true, specClass)
    }
 
    /**


### PR DESCRIPTION
bug: when adding config to the describe / context containers, it stops showing the tree under them

```
describe("Deals additional profit").config(timeout = 60.minutes) {
    // a lot of different contexts and it blocks
}
```

<img width="546" height="129" alt="image" src="https://github.com/user-attachments/assets/94eb96de-6ad4-4d91-9e61-6d8fa086e374" />

