### PR TITLE
feat(toolwindow): save state of the branches across files

### DIFF
--- a/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/TestExplorerWindow.kt
+++ b/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/TestExplorerWindow.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.fileEditor.FileEditorManagerEvent
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.SimpleToolWindowPanel
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.openapi.vfs.newvfs.BulkFileListener
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent
@@ -104,7 +105,7 @@ class TestExplorerWindow(private val project: Project) : SimpleToolWindowPanel(t
       project.messageBus.connect().subscribe(
          FileEditorManagerListener.FILE_EDITOR_MANAGER,
          object : FileEditorManagerListener {
-            override fun fileClosed(source: FileEditorManager, file: com.intellij.openapi.vfs.VirtualFile) {
+            override fun fileClosed(source: FileEditorManager, file: VirtualFile) {
                // when a file is closed, reset the one-time expanded state so reopening expands all again
                tree.markFileClosed(file)
             }

--- a/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/TestExplorerWindow.kt
+++ b/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/TestExplorerWindow.kt
@@ -104,6 +104,11 @@ class TestExplorerWindow(private val project: Project) : SimpleToolWindowPanel(t
       project.messageBus.connect().subscribe(
          FileEditorManagerListener.FILE_EDITOR_MANAGER,
          object : FileEditorManagerListener {
+            override fun fileClosed(source: FileEditorManager, file: com.intellij.openapi.vfs.VirtualFile) {
+               // when a file is closed, reset the one-time expanded state so reopening expands all again
+               tree.markFileClosed(file)
+            }
+
             override fun selectionChanged(event: FileEditorManagerEvent) {
                val file = fileEditorManager.selectedEditor?.file
                if (file != null) {

--- a/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/TestFileTree.kt
+++ b/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/TestFileTree.kt
@@ -3,6 +3,7 @@ package io.kotest.plugin.intellij.toolwindow
 import com.intellij.ide.util.treeView.NodeRenderer
 import com.intellij.ide.util.treeView.PresentableNodeDescriptor
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.ui.TreeUIHelper
 import javax.swing.tree.DefaultMutableTreeNode
 import javax.swing.tree.TreeModel
@@ -17,6 +18,10 @@ class TestFileTree(
    private val kotestTestExplorerService: KotestTestExplorerService =
       project.getService(KotestTestExplorerService::class.java)
    private var initialized = false
+   private val filesInitiallyExpanded = mutableSetOf<String>()
+   private var lastFileKey: String? = null
+   private val savedExpandedByFile = mutableMapOf<String, Set<String>>()
+   private val savedAllKeysByFile = mutableMapOf<String, Set<String>>()
 
    init {
       selectionModel.selectionMode = TreeSelectionModel.SINGLE_TREE_SELECTION
@@ -40,13 +45,64 @@ class TestFileTree(
          super.setModel(treeModel)
          return
       }
-      val expanded = isExpanded(0)
+      val newFileKey = currentFileKey()
+
+      // If switching away from a file, save its state first
+      if (lastFileKey != null && lastFileKey != newFileKey) {
+         savedExpandedByFile[lastFileKey!!] = collectExpandedPathKeys()
+         savedAllKeysByFile[lastFileKey!!] = collectAllPathKeys()
+      }
+
+      val firstOpenForFile = newFileKey != null && !filesInitiallyExpanded.contains(newFileKey)
+      val sameFile = newFileKey == lastFileKey
+
+      // Prepare previous keys/expansion baselines
+      val prevAllKeysForThisFile: Set<String> = when {
+         firstOpenForFile -> emptySet()
+         sameFile -> collectAllPathKeys()
+         newFileKey != null -> savedAllKeysByFile[newFileKey] ?: emptySet()
+         else -> emptySet()
+      }
+      val expandedKeysToRestore: Set<String> = when {
+         firstOpenForFile -> emptySet()
+         sameFile -> collectExpandedPathKeys()
+         newFileKey != null -> savedExpandedByFile[newFileKey] ?: emptySet()
+         else -> emptySet()
+      }
+
       super.setModel(treeModel)
-      expandAllNodes()
-      setModuleGroupNodeExpandedState(expanded)
+
+      // Compute added nodes relative to the previous snapshot of this file (if any)
+      val newAllKeys = collectAllPathKeys()
+      if (!firstOpenForFile) {
+         val addedKeys = newAllKeys - prevAllKeysForThisFile
+         if (addedKeys.isNotEmpty()) expandAncestorPrefixesFor(addedKeys)
+      }
+
+      if (firstOpenForFile) {
+         // First time this file is shown in the tool window: expand everything
+         expandAllNodes()
+         newFileKey?.let { filesInitiallyExpanded.add(it) }
+      } else {
+         // Restore previous expansion state for this file
+         if (expandedKeysToRestore.isNotEmpty()) expandPathsByKeys(expandedKeysToRestore)
+      }
+
+      // Update caches for this file and mark it as current
+      if (newFileKey != null) {
+         savedAllKeysByFile[newFileKey] = newAllKeys
+         savedExpandedByFile[newFileKey] = collectExpandedPathKeys()
+      }
+      lastFileKey = newFileKey
    }
 
-   private fun setModuleGroupNodeExpandedState(expanded: Boolean) {
-      if (expanded) expandRow(0) else collapseRow(0)
+   fun markFileClosed(file: VirtualFile) {
+      filesInitiallyExpanded.remove(file.path)
+      savedExpandedByFile.remove(file.path)
+      savedAllKeysByFile.remove(file.path)
+      if (lastFileKey == file.path) lastFileKey = null
    }
+
+   private fun currentFileKey(): String? = kotestTestExplorerService.currentFile?.path
+
 }

--- a/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/TestFileTree.kt
+++ b/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/TestFileTree.kt
@@ -87,7 +87,7 @@ class TestFileTree(
       }
 
       if (firstOpenForFile) {
-         // First time this file is shown in the tool window: expand everything except Modules
+         // First time this file is shown in the tool window: expand everything
          expandAllNodes()
          stateByFileKey[newFileKey] = FileTreeState(newAllKeys, collectExpandedPathKeys(), initiallyExpanded = true)
       } else {

--- a/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/treeutils.kt
+++ b/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/treeutils.kt
@@ -34,3 +34,104 @@ fun TreePath.nodeDescriptor(): PresentableNodeDescriptor<*>? {
       else -> null
    }
 }
+
+// --- Expansion state helpers ---
+
+/**
+ * Builds a logical key for a node to preserve expansion state across model rebuilds.
+ * Only nodes that can have children are keyed (root, modules, module, tags, file, spec, container test).
+ */
+private fun DefaultMutableTreeNode.expansionKeyOrNull(): String? {
+   return when (val descriptor = userObject) {
+      is KotestRootNodeDescriptor -> "root"
+      is ModulesNodeDescriptor -> "modules"
+      is ModuleNodeDescriptor -> "module:${descriptor.module.name}"
+      is TagsNodeDescriptor -> "tags"
+      is TestFileNodeDescriptor -> "file"
+      is SpecNodeDescriptor -> "spec:${descriptor.fqn.asString()}"
+      is TestNodeDescriptor -> {
+         // Only container tests can have children; still safe to key all tests
+         "test:${descriptor.test.test.descriptorPath()}"
+      }
+      else -> null
+   }
+}
+
+/**
+ * Returns a set of expansion path keys for the currently expanded nodes.
+ */
+fun JTree.collectExpandedPathKeys(): Set<String> {
+   val root = model.root as? DefaultMutableTreeNode ?: return emptySet()
+   val expanded = mutableSetOf<String>()
+   // Enumerate all expanded descendants starting from root
+   val enumeration = getExpandedDescendants(TreePath(root.path)) ?: return emptySet()
+   while (enumeration.hasMoreElements()) {
+      val path = enumeration.nextElement()
+      val key = pathToExpansionKey(path)
+      if (key != null) expanded.add(key)
+   }
+   return expanded
+}
+
+/**
+ * Expands nodes in the current model whose logical expansion keys appear in [keys].
+ */
+fun JTree.expandPathsByKeys(keys: Set<String>) {
+   val root = model.root as? DefaultMutableTreeNode ?: return
+   fun recurse(node: DefaultMutableTreeNode, prefix: String?) {
+      val key = node.expansionKeyOrNull()
+      val pathKey = if (key == null) prefix else listOfNotNull(prefix, key).joinToString("/")
+      if (pathKey != null && keys.contains(pathKey)) {
+         expandPath(TreePath(node.path))
+      }
+      val children = node.children()
+      while (children.hasMoreElements()) {
+         val child = children.nextElement() as DefaultMutableTreeNode
+         recurse(child, pathKey)
+      }
+   }
+   recurse(root, null)
+}
+
+private fun pathToExpansionKey(path: TreePath): String? {
+   val parts = path.path
+      .mapNotNull { it as? DefaultMutableTreeNode }
+      .mapNotNull { it.expansionKeyOrNull() }
+   return if (parts.isEmpty()) null else parts.joinToString("/")
+}
+
+/**
+ * Returns a set of path keys for all nodes in the current model.
+ */
+fun JTree.collectAllPathKeys(): Set<String> {
+   val root = model.root as? DefaultMutableTreeNode ?: return emptySet()
+   val keys = mutableSetOf<String>()
+   fun recurse(node: DefaultMutableTreeNode) {
+      val path = TreePath(node.path)
+      val key = pathToExpansionKey(path)
+      if (key != null) keys.add(key)
+      val children = node.children()
+      while (children.hasMoreElements()) {
+         recurse(children.nextElement() as DefaultMutableTreeNode)
+      }
+   }
+   recurse(root)
+   return keys
+}
+
+/**
+ * Expands all ancestor prefixes for the given full path keys.
+ */
+fun JTree.expandAncestorPrefixesFor(keys: Set<String>) {
+   if (keys.isEmpty()) return
+   val toExpand = mutableSetOf<String>()
+   keys.forEach { key ->
+      val parts = key.split('/')
+      val acc = mutableListOf<String>()
+      parts.forEach { part ->
+         acc.add(part)
+         toExpand.add(acc.joinToString("/"))
+      }
+   }
+   expandPathsByKeys(toExpand)
+}


### PR DESCRIPTION
use cases:

1. User collapses some branches for better readability
2. User adds new branch

1. User collapses some branches
2. User editing the branch inside collapsed

1. User collapses some branches
2. User switches to another file. For example, for debug
3. User returns to the tests

Current: expands all branches
Proposed: 
saves the state before switching to another file
saves the state before adding / removing branch and restores the previous tree with newly added / removed branch
opens all ancestors when adding / removing branch inside collapsed

If the file was closed then clear the state of this file